### PR TITLE
Remove overlays.list

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -11,8 +11,8 @@ chmod 755 $INSTALLER/common/keycheck
 
 # remove /data/resource-cache/overlays.list
 OVERLAY='/data/resource-cache/overlays.list'
-ui_print "   Removing $OVERLAY"
 if [ -f "$OVERLAY" ] ;then
+  ui_print "   Removing $OVERLAY"
   rm -f "$OVERLAY"
 fi
 

--- a/common/install.sh
+++ b/common/install.sh
@@ -9,6 +9,11 @@ esac
 # Keycheck binary by someone755 @Github, idea for code below by Zappo @xda-developers
 chmod 755 $INSTALLER/common/keycheck
 
+# remove /data/resource-cache/overlays.list
+OVERLAY='/data/resource-cache/overlays.list'
+ui_print "   Removing $OVERLAY"
+rm -f "$OVERLAY"
+
 keytest() {
   ui_print " - Vol Key Test -"
   ui_print "   Press Vol Up:"
@@ -110,10 +115,6 @@ else
 fi
 
 if [ ! -z $LAUNCHER ]; then
-  # remove /data/resource-cache
-  ui_print "   Removing /data/resource-cache!"
-  rm -rf /data/resource-cache
-
   mkdir -p $INSTALLER/system/priv-app/NexusLauncherPrebuilt
   cp -f $INSTALLER/custom/$LAUNCHER/PixelLauncher.apk $INSTALLER/system/priv-app/NexusLauncherPrebuilt/NexusLauncherPrebuilt.apk
 fi

--- a/common/install.sh
+++ b/common/install.sh
@@ -12,7 +12,9 @@ chmod 755 $INSTALLER/common/keycheck
 # remove /data/resource-cache/overlays.list
 OVERLAY='/data/resource-cache/overlays.list'
 ui_print "   Removing $OVERLAY"
-rm -f "$OVERLAY"
+if [ -f "$OVERLAY" ] ;then
+  rm -f "$OVERLAY"
+fi
 
 keytest() {
   ui_print " - Vol Key Test -"


### PR DESCRIPTION
Sun Apr 29 10:40:17 BST 2018

`CircleIconsOverlay.apk` was causing `/data/resource-cache/overlays.list` to
be created.  When it was removed from the module, the remnant
`overlays.list` was causing `android.ui` to crash.